### PR TITLE
Add  secondaryFiles: for refFiles

### DIFF
--- a/pcawg_minibam_wf.cwl
+++ b/pcawg_minibam_wf.cwl
@@ -31,6 +31,8 @@ inputs:
       type: Directory
     refFile:
       type: File
+      secondaryFiles:
+       - .fai
     out_dir:
       type: string
     normalBam:


### PR DESCRIPTION
Fix the error of 
Cannot make scatter job: Missing required secondary file 'genome.fa.fai' from file object: {
    "class": "File",
    "location": "file:///mnt/PBCP/pcawg/ref_coclean/genome.fa",
    "size": 3189750467,
    "basename": "genome.fa",
    "nameroot": "genome",
    "nameext": ".fa",
    "secondaryFiles": []
}